### PR TITLE
Fixed compatibility issues

### DIFF
--- a/GUI/generalFunc/turnOffFigureSelection.m
+++ b/GUI/generalFunc/turnOffFigureSelection.m
@@ -16,6 +16,10 @@ function [h_pan,h_zoom,h_cursor] = turnOffFigureSelection(h)
 % Contact: sandra.vanaert@uantwerpen.be
 %--------------------------------------------------------------------------
 
+% Determine Matlab version for compatibility
+v = version('-release');
+v = str2double(v(1:4));
+
 % First turn off zoom, pan and datacursor
 h_pan = pan(h.fig);
 h_zoom = [h.zoom.in;h.zoom.out];
@@ -23,4 +27,10 @@ h_cursor = datacursormode(h.fig);
 h_cursor.removeAllDataCursors();
 set(h_pan,'Enable','off')
 set(h_cursor,'Enable','off')
-zoomAxinFig(h,'off')
+
+if v < 2019
+    zoomAxinFig(h,'off')
+else
+    h_z = zoom(h.fig);
+    h_z.Enable = 'off';
+end


### PR DESCRIPTION
Fixed GUI interface compatibility issue causing StatSTEM GUI to crash under MATLAB 2019a when clicking button while in zoom mode.