### PR TITLE
Bugfixes

### DIFF
--- a/functions/@outputStatSTEM/showHistogramSCS.m
+++ b/functions/@outputStatSTEM/showHistogramSCS.m
@@ -23,8 +23,8 @@ end
 val = obj.selVol;
 bins = getNBins(val);
 hist(val,bins);
-xlabel('Scattering cross-section (e^-Å^2)')
-ylabel('Frequency')
+xlabel('Scattering cross-section $\left[\mathrm{e/\AA^2}\right]$','Interpreter','LaTex')
+ylabel('Frequency','Interpreter','LaTex')
 
 % Make color gray
 h = findobj(ax,'Type','patch');


### PR DESCRIPTION
 - Initial parameters for the function [`criterionGauss_diffrho`](functions/FitProgram/criterionGauss_diffrho.m) "StartParametersnonlin_s" missed a third parameter, causing the computations for Jacobians to be wrong
![image](https://user-images.githubusercontent.com/47680554/105179549-c281b800-5b29-11eb-8721-fdd5cde2910a.png)
![image](https://user-images.githubusercontent.com/47680554/105179595-ce6d7a00-5b29-11eb-8e85-374c72240f50.png)
 - Omitted some unneccary/redundant computations
 - Fixed incorrect and non-cross-platform-compatible Plot label at SCS-histogram