### PR TITLE
26 improve starting values locations

### DIFF
--- a/functions/@outputStatSTEM/fitGMM.m
+++ b/functions/@outputStatSTEM/fitGMM.m
@@ -45,7 +45,7 @@ n_c = obj.n_c;
 for k = 1:n_c
     obj_s = cell(1,k);
     if k == 1
-        mustart = (max(data) - min(data))/2;
+        mustart = (max(data) + min(data))/2;
         sigmastart  = (max(data)-min(data))/(2*k);
         s = struct('mu', mustart', 'Sigma', sigmastart^2, 'Pcomponents', ones(k,1)/k);
         warning('off','all')


### PR DESCRIPTION
Changes were made to the function fitGMM.m, specifically to the starting values of the locations of the Gaussian mixture model. In the proposed code, several sets of random starting values are used for the locations of the GMM at each number of components. Previously, the starting values for k+1 components were constructed by adding 1 extra location (at several places to still try to avoid local minima). However, this new code should be more general, and cover the range of the data in a more objective way for considering which set of starting values is most suitable.

The changes did however render the code a bit slower, since more options are considered. A first test for the Example_PtIr.mat file shows a difference in the ICL values, but the same relevant local minimum can be found and it yields equivalent atom-counting results.